### PR TITLE
adding pages for dssp, eccentricity, and gangle + slight mod to gmx dist

### DIFF
--- a/docs/Molecular Dynamics/GROMACS/gmx-dist.md
+++ b/docs/Molecular Dynamics/GROMACS/gmx-dist.md
@@ -37,6 +37,8 @@ This produces the following outputs:
 
 * `-oav`: average distances as a function of time
 * `-oxyz`: distance components (x-/y-/z-axis) as a function of time
+* 
+These XVG files can be visualized using Python or Grace to produce a plots of distance versus time, or to generate a heat-map.
 
 ## Using `gmx mindist`
 

--- a/docs/Molecular Dynamics/GROMACS/gmx-dssp.md
+++ b/docs/Molecular Dynamics/GROMACS/gmx-dssp.md
@@ -1,0 +1,67 @@
+# Determining Secondary Structure (DSSP)
+
+## Introduction
+
+`gmx do_dssp` determines a protein's secondary structure based on hydrogen bonding patterns between residues. DSSP is able to determine the formation of/changes in  helices, sheets, and disordered regions (coils). This allows us to study how a protein's conformation may morph and move throughout the span of a simulation.
+
+You should have the following files:
+
+* Trajectory files (.xtc)
+* Structure or topology file (.gro/.tpr)
+* Index file (.ndx)
+
+!!! note
+    `gmx do_dssp` was changed to `gmx dssp` in the 2023 version of GROMACS. This page references the older `do_dssp` command.
+
+## Using `gmx do_dssp`
+
+To determine the secondary structure of your proteins:
+
+```bash
+gmx do_dssp -f trajectory.xtc -s structure.gro -n index.ndx -tu ns -o ss.xpm -sc sscount.xvg
+```
+
+GRO and TPR files may be used interchangeably for the `-s` option. If you are trying to determine the secondary structure of a multi-subunit protein with identical chains (homo-oligomers), you may need to create a [custom GRO file](#using-gmx-do_dssp-with-homo-oligomeric-proteins) to properly run this command.
+
+`gmx do_dssp` produces the following outputs:
+
+* `-o`: structure assignment as a function of time
+* `-sc`: structure count as a function of time
+
+Both the XPM (`-o`) and XVG (`-sc`) files can be parsed using Python or Grace for visualization. XPM files can also be processed through [`gmx xpm2ps`](https://manual.gromacs.org/current/onlinehelp/gmx-xpm2ps.html). This will transform the data into a labelled plot that may be opened through programs like [GIMP](https://www.gimp.org/).
+
+### Using `gmx do_dssp` with homo-oligomeric proteins
+
+Homo-oligomers have the same residue numbers designated across identical subunits. This creates issues with the DSSP algorithm, causing the command to stall at the first frame of the simulation. To get around this, you will need to create GRO and NDX files with each protein residue renumbered sequentially.
+
+If you do not have an original GRO file, you can generate one:
+
+```bash
+gmx trjconv -f trajectory.xtc -s topology.tpr -o structure.gro
+```
+
+To edit this GRO file and renumber the protein residues:
+
+```bash
+gmx editconf -f structure.gro -resnr 1 -o renumbered.gro
+```
+
+`-resnr` indicates the residue number to start from, in this case 1.
+
+---
+
+If you are analyzing specific parts of your protein, you will need to create a new NDX file using the renumbered GRO file:
+
+```bash
+gmx make_ndx -f renumbered.gro -o renumbered.ndx
+```
+
+If you are unsure of how to use this command to create special atom groups, refer to the [guide on GROMACS index files](gmx-ndx.md).
+
+---
+
+Both renumbered files can be used as an input for the `-s` option as described in the [Using `gmx do_dssp`](#using-gmx-do_dssp) section.
+
+## Additional Resources
+
+* [gmx do_dssp](https://manual.gromacs.org/2022/onlinehelp/gmx-do_dssp.html)

--- a/docs/Molecular Dynamics/GROMACS/gmx-eccentricity.md
+++ b/docs/Molecular Dynamics/GROMACS/gmx-eccentricity.md
@@ -1,0 +1,48 @@
+# Measuring Eccentricity
+
+## Introduction
+
+**Eccentricity** is a measure of how much a protein or complex's shape deviates from a sphere, or its roundness.
+
+Eccentricity (*e*) is calculated using the moments of inertia (*I*) from the three principal axes (x, y, z). Values of *e* closer to 0 are considered more spherical, while values closer to 1 are more ellipsoid.
+
+*e* can be calculated using the following equation[^1]:
+<figure markdown="span">
+  ![Equation for eccentricity. Eccentricity = sqrt(1 - ((Ix + Iy - Iz) / (-Ix + Iy + Iz)))](../../assets/GROMACS/gyrate-sasa/gmx_gyrate_moi_2.png){ width="300" }
+</figure>
+
+[^1]: This is the equation used in the lab to determine *e*. Occasionally, you will find literature that also uses a more simplified equation of *e* = 1 - (I~min~/I~avg~).
+
+*I* for each axis can be calculated using `gmx gyrate` with the `-moi` option. Note that `gmx principal` may also be used to determine *I*, but `gmx gyrate` is currently supported in scripts used by our lab.
+
+You should have the following files:
+
+* Trajectory files (.xtc)
+* Topology file (.tpr)
+
+!!! note
+    `gmx gyrate` was changed in the 2024 version of GROMACS. This page references the command as it was in prior releases.
+
+## Using `gmx gyrate`
+
+To calculate moments of inertia using `gmx gyrate`:
+
+```
+gmx gyrate -f trajectory.xtc -s topology.tpr -o moi.xvg -moi
+```
+
+???+ tip "Other options you may find useful"
+
+    * `-n`: index file to be used (see [Creating Index Files](gmx-ndx.md))
+    * `-b` and `-e`: the frames to <ins>b</ins>egin and <ins>e</ins>nd
+
+!!! warning
+    You **MUST** use the `-moi` option, otherwise GROMACS will calculate [radius of gyration](gmx-gyrate.md) instead.
+  
+When prompted, select the atom group you wish to analyze. Special groups will require a custom index file to be supplied with `-n`.
+
+This will output an XVG file of *I* versus time. This file can be processed to extract each value and calculate the eccentricity of your protein. Alternatively, it can also be visualized using Grace or Python, as is.
+
+## Additional Resources
+
+* [gmx gyrate](https://manual.gromacs.org/2023-current/onlinehelp/gmx-gyrate.html)

--- a/docs/Molecular Dynamics/GROMACS/gmx-gangle.md
+++ b/docs/Molecular Dynamics/GROMACS/gmx-gangle.md
@@ -1,0 +1,41 @@
+# Measuring Angles
+
+## Introduction
+
+`gmx gangle` can be used to calculate the angles between groups of vectors. Specifically, `gmx gangle` can compute angles between a vector or plane and another vector, plane, the z-axis, or the normal vector of a sphere. It can also compute angles and dihedrals, similar to `gmx angle`.
+
+Like the [`gmx distance` command](gmx-dist.md), this command allows us to study movement of features, like protein hinges.
+
+!!! note
+    You will need to use a [custom index file](gmx-ndx.md) if you are measuring angles between custom groups of atoms.
+
+You should have the following files:
+
+* Trajectory files (.xtc)
+* Topology file (.tpr)
+* Index file (.ndx)
+
+## Using `gmx gangle`
+
+To calculate angles:
+
+```bash
+gmx gangle -f trajectory.xtc -s topology.tpr -n index.ndx -tu ns -oav all-angles.xvg -oall all-angles.xvg  -oh angle-hist.xvg -g1 vector -group1 <group> -g2 vector -group2 <group> 
+```
+
+`-g1` and `-g2` indicate the type of angle that should be analyzed (`vector`, `plane`, `angle`, or `dihedral`). These options are closely tied to the `-group1` and `-group2` options, which specify the atom positions to be analyzed. The groups to be analyzed are taken from the index file supplied with `-n`.
+
+As the inputs for these options are highly dependent on the system, refer to the [`gmx gangle` documentation page](https://manual.gromacs.org/current/onlinehelp/gmx-gangle.html) for valid `-g1/g2` and `-group1/group2` combinations.
+
+This produces the following outputs:
+
+* `-oav`: average angles as a function of time
+* `-oall`: all angles as a function of time
+* `-oh`: histogram of angles
+
+These XVG files can be visualized using Python or Grace to produce a plots of angle versus time, or to generate a heat-map from histogram data.
+
+## Additional Resources
+
+* [gmx gangle](https://manual.gromacs.org/current/onlinehelp/gmx-gangle.html)
+* [Bonds/distances, angles and dihedrals (GROMACS reference manual)](https://manual.gromacs.org/current/reference-manual/analysis/bond-angle-dihedral.html)


### PR DESCRIPTION
- Added GROMACS doc pages on gmx do_dssp, gmx gangle + gmx gyrate for eccentricity analysis. This should fill out the random "None" pages in the navigation under the GROMACS section of Molecular Dynamics.
- Added one line in gmx dist to clarify data processing